### PR TITLE
[Optional enhancement] Ignore extra spaces and allow user to escape with /

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -24,7 +24,8 @@ public class ArgumentTokenizer {
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
-        String newString = argsString.replaceAll(" +"," ").replaceAll("//", Character.toString((char) 127));
+        String newString = argsString.replaceAll(" +", " ")
+            .replaceAll("//", Character.toString((char) 127));
         List<PrefixPosition> positions = findAllPrefixPositions(newString, prefixes);
         return extractArguments(newString, positions);
     }
@@ -122,7 +123,8 @@ public class ArgumentTokenizer {
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
-        return value.trim().replaceAll("/","").replaceAll(Character.toString((char) 127), "/");
+        return value.trim().replaceAll("/", "")
+            .replaceAll(Character.toString((char) 127), "/");
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -24,8 +24,9 @@ public class ArgumentTokenizer {
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
-        List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
-        return extractArguments(argsString, positions);
+        String newString = argsString.replaceAll(" +"," ").replaceAll("//", Character.toString((char) 127));
+        List<PrefixPosition> positions = findAllPrefixPositions(newString, prefixes);
+        return extractArguments(newString, positions);
     }
 
     /**
@@ -121,7 +122,7 @@ public class ArgumentTokenizer {
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
-        return value.trim();
+        return value.trim().replaceAll("/","").replaceAll(Character.toString((char) 127), "/");
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -59,7 +59,7 @@ public class ArgumentTokenizerTest {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString);
 
         // Same string expected as preamble, but leading/trailing spaces should be trimmed
-        assertPreamblePresent(argMultimap, argsString.trim());
+        assertPreamblePresent(argMultimap, argsString.trim().replaceAll("/", ""));
 
     }
 
@@ -128,7 +128,7 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void tokenize_multipleArgumentsJoined() {
-        String argsString = "SomePreambleStringp/ pSlash joined-tjoined -t not joined^Qjoined";
+        String argsString = "SomePreambleStringp// pSlash joined-tjoined -t not joined^Qjoined";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleStringp/ pSlash joined-tjoined");
         assertArgumentAbsent(argMultimap, pSlash);


### PR DESCRIPTION
Tokenizer strips all more than one spaces and replaces it with one space.
User can enter characters that match command tags like n/ by inputting n// 
//// becomes //
If there is a odd number of / like /// in parameters(not n/ or s/) one will be removed to make it even.