### PR TITLE
Fix findo

### DIFF
--- a/src/main/java/seedu/pharmhub/logic/parser/FindOrderCommandParser.java
+++ b/src/main/java/seedu/pharmhub/logic/parser/FindOrderCommandParser.java
@@ -1,8 +1,7 @@
 package seedu.pharmhub.logic.parser;
 
 import static seedu.pharmhub.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.pharmhub.logic.parser.CliSyntax.PREFIX_MEDICINE_NAME;
-import static seedu.pharmhub.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.pharmhub.logic.parser.CliSyntax.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -10,6 +9,7 @@ import java.util.Set;
 
 import seedu.pharmhub.logic.commands.FindOrderCommand;
 import seedu.pharmhub.logic.parser.exceptions.ParseException;
+import seedu.pharmhub.model.allergy.Allergy;
 import seedu.pharmhub.model.medicine.Medicine;
 import seedu.pharmhub.model.order.Status;
 import seedu.pharmhub.model.order.exceptions.InvalidStatusException;
@@ -39,10 +39,10 @@ public class FindOrderCommandParser implements Parser<FindOrderCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindOrderCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STATUS, PREFIX_MEDICINE_NAME);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STATUS);
 
+        Set<Medicine> medicinesToFind = ParserUtil.parseMedicines(argMultimap.getAllValues(PREFIX_MEDICINE_NAME));
         Status statusToFind = null;
-        Set<Medicine> medicineToFind = null;
 
         if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
             try {
@@ -53,18 +53,13 @@ public class FindOrderCommandParser implements Parser<FindOrderCommand> {
                 throw new ParseException(se.getMessage());
             }
         }
-        if (argMultimap.getValue(PREFIX_MEDICINE_NAME).isPresent()) {
-            String medicineArg = argMultimap.getValue(PREFIX_MEDICINE_NAME).get();
-            List<String> list = Arrays.asList(medicineArg.split("\\s+"));
-            medicineToFind = ParserUtil.parseMedicines(list);
-        }
 
-        if (statusToFind == null && medicineToFind == null) {
+        if (statusToFind == null && medicinesToFind.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindOrderCommand.MESSAGE_USAGE));
         }
 
-        return new FindOrderCommand(statusToFind, medicineToFind);
+        return new FindOrderCommand(statusToFind, medicinesToFind);
     }
 
 }

--- a/src/main/java/seedu/pharmhub/logic/parser/FindOrderCommandParser.java
+++ b/src/main/java/seedu/pharmhub/logic/parser/FindOrderCommandParser.java
@@ -1,15 +1,13 @@
 package seedu.pharmhub.logic.parser;
 
 import static seedu.pharmhub.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.pharmhub.logic.parser.CliSyntax.*;
+import static seedu.pharmhub.logic.parser.CliSyntax.PREFIX_MEDICINE_NAME;
+import static seedu.pharmhub.logic.parser.CliSyntax.PREFIX_STATUS;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 import seedu.pharmhub.logic.commands.FindOrderCommand;
 import seedu.pharmhub.logic.parser.exceptions.ParseException;
-import seedu.pharmhub.model.allergy.Allergy;
 import seedu.pharmhub.model.medicine.Medicine;
 import seedu.pharmhub.model.order.Status;
 import seedu.pharmhub.model.order.exceptions.InvalidStatusException;


### PR DESCRIPTION
From v1.3 UG: This was the supposed command format for findo.
<img width="646" alt="Screenshot 2023-11-14 at 2 04 25 AM" src="https://github.com/AY2324S1-CS2103T-W08-4/tp/assets/77560009/0d0f40cf-7725-442f-bf10-2a29df58b3d8">

From v1.3 App: This was the command format given on error
<img width="1069" alt="Screenshot 2023-11-14 at 2 05 17 AM" src="https://github.com/AY2324S1-CS2103T-W08-4/tp/assets/77560009/abebfda2-e1d3-4672-8f39-f058c30207a8">

However, findo would not accept multiple medicine flags, and instead allowed for space separated medicine names after the m/ flag. This is clearly incorrect behaviour.

Ironically, there is also a UG bug with regard to the above: Findo parameters are optional (correctly indicated in the application), which is wrongly stated in the UG to be compulsory. As such, the UG will be updated to match the command format in the error message.
